### PR TITLE
Don't dispose controller owned by someone else

### DIFF
--- a/lib/flutter_pw_validator.dart
+++ b/lib/flutter_pw_validator.dart
@@ -170,11 +170,4 @@ class _FlutterPwValidatorState extends State<FlutterPwValidator> {
       ),
     );
   }
-
-  //Dispose the TextField controller
-  @override
-  void dispose() {
-    widget.controller.dispose();
-    super.dispose();
-  }
 }


### PR DESCRIPTION
Disposing the `TextEditingController` should be done by the one who created the controller.

If it is disposed in the place where it was created it will lead to the following Error instead:

```
The following assertion was thrown while finalizing the widget tree:
A TextEditingController was used after being disposed.

Once you have called dispose() on a TextEditingController, it can no longer be used.
When the exception was thrown, this was the stack: 
```

Moreover it might be that the `TextEditingController` is still needed even after the `FlutterPWValidator` is no longer needed