### PR TITLE
added support for in-between spacing

### DIFF
--- a/lib/Utilities/SizeConfig.dart
+++ b/lib/Utilities/SizeConfig.dart
@@ -4,4 +4,5 @@ class SizeConfig {
 
   static double? width;
   static double? height;
+  static double? spaceBetween;
 }

--- a/lib/flutter_pw_validator.dart
+++ b/lib/flutter_pw_validator.dart
@@ -18,7 +18,7 @@ class FlutterPwValidator extends StatefulWidget {
       numericCharCount,
       specialCharCount;
   final Color defaultColor, successColor, failureColor;
-  final double width, height;
+  final double width, height, spaceBetween;
   final Function onSuccess;
   final Function? onFail;
   final TextEditingController controller;
@@ -31,6 +31,7 @@ class FlutterPwValidator extends StatefulWidget {
       required this.minLength,
       required this.onSuccess,
       required this.controller,
+      this.spaceBetween = 0,
       this.uppercaseCharCount = 0,
       this.lowercaseCharCount = 0,
       this.numericCharCount = 0,
@@ -45,6 +46,7 @@ class FlutterPwValidator extends StatefulWidget {
     //Initial entered size for global use
     SizeConfig.width = width;
     SizeConfig.height = height;
+    SizeConfig.spaceBetween = spaceBetween;
   }
 
   @override
@@ -168,7 +170,7 @@ class FlutterPwValidatorState extends State<FlutterPwValidator> {
       width: SizeConfig.width,
       height: widget.height,
       child: new Column(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        mainAxisAlignment: MainAxisAlignment.start,
         children: [
           new Flexible(
             flex: 3,
@@ -187,6 +189,10 @@ class FlutterPwValidatorState extends State<FlutterPwValidator> {
                     new ValidationBarComponent(color: widget.defaultColor)
               ],
             ),
+          ),
+          new SizedBox(
+            width: SizeConfig.width,
+            height: SizeConfig.spaceBetween,
           ),
           new Flexible(
             flex: 7,


### PR DESCRIPTION
The Info text bullet points were often getting pushed down in the column and it was difficult to control its distance from the "bars" showing the validation steps using height only, as restricting the height would cause the bullet points to overflow. With these changes, elements of the validator are now aligned to the start of the column and a new SizedBox spacer has been added to control spacing between the two validator visual features (the bars / the text)